### PR TITLE
Explicitly call out self in the signature

### DIFF
--- a/HelpMeGUIWanKenobi.py
+++ b/HelpMeGUIWanKenobi.py
@@ -6,7 +6,7 @@ import tkinter as tk
 
 def grid(num_rows, num_columns):
     def real_decorator(func):
-        def wrapper(*args, **kwargs):
+        def wrapper(self, *args, **kwargs):
             result = func(*args, **kwargs)
             for rows in range(num_rows):
                 return self.grid_rowconfigure(rows, weight=1)


### PR DESCRIPTION
A decorator replaces the __init__ call with itself, so of course it captures "self". In the original code, it's part of args, but this will call it out explicitly, since it (should) always be present.